### PR TITLE
[Biggie] Add Homebrew SDL include file location for M1 Macs

### DIFF
--- a/tools/biggie/biggie-MacOSX-compile.sh
+++ b/tools/biggie/biggie-MacOSX-compile.sh
@@ -4,6 +4,7 @@
 
 /usr/bin/gcc                                       \
     -D _MACOSX                                     \
+    -I /opt/homebrew/include/SDL                   \
     -I ../../Mac/SDL2.framework/Headers            \
     -I ../../src/SDL                               \
     -I ../../src/ThirdParty/CRC                    \


### PR DESCRIPTION
Issue: The biggie-MacOSX-compile.sh script will fail in Terminal on Apple Silicon. 

Reason:  Homebrew uses /opt/homebrew to install Arm64 files (keeping /usr/local for intel builds) so the build script can't locate them.

Fix: Adding the Homebrew SDL headers location allows the script to correctly locate the SDL header files. 

Testing: Try to run the script on both Intel and Arm Macs to confirm it still builds. 